### PR TITLE
Added helper functions for accessing parent directories with the .cml…

### DIFF
--- a/command.ml
+++ b/command.ml
@@ -166,7 +166,7 @@ let parse_input (args : string array) : input =
 (* executes a Cml command *)
 let execute (i : input) : unit =
   try
-    if not (i.cmd = Init || i.cmd = Help) && not (cml_initialized "./") then
+    if not (i.cmd = Init || i.cmd = Help) && not (cml_initialized_r "./") then
       raise (Fatal "Not a Cml repository (or any of the parent directories)")
     else
       match i.cmd with

--- a/utils.ml
+++ b/utils.ml
@@ -21,13 +21,47 @@ let perm = 0o777
 (***************************** Generic Helpers ********************************)
 (******************************************************************************)
 
-(* returns true if the current directory (or parent) is an initialized Cml repo,
- * otherwise raises an exception *)
+(* returns the option path to the nearest .cml directory from the cwd
+ * (current working directory). *)
+let cml_path path =
+  let rec cml_path_helper i acc =
+    if i = 0 then
+      raise (Fatal "Not a Cml repository (or any of the parent directories)")
+    else
+      if Sys.file_exists (acc^".cml") then
+        Some acc
+      else
+        cml_path_helper (i-1) (acc^"../")
+  in
+  let cwd = Sys.getcwd () in
+  let i = ref 0 in
+  String.iter (fun c -> if c = '/' then incr i else ()) cwd;
+  cml_path_helper !i path
+
+(* returns true if the path contains an initialized Cml repo,
+ * otherwise returns false *)
 let cml_initialized (path : string) : bool =
-  Sys.file_exists ".cml"
+  Sys.file_exists (path^".cml")
+
+(* returns true if the current directory (or parent) is an initialized Cml repo,
+ * otherwise returns false *)
+let cml_initialized_r path =
+  match cml_path path with
+  | Some _ -> true
+  | None -> false
+
+(* sets the cwd (current working directory) to the nearest .cml directory.
+ * Raises Fatal exception if directory is not a Cml repository
+ * (or any of the parent directories) *)
+let chdir_to_cml () =
+  match cml_path ((Sys.getcwd ())^"/") with
+  | Some path -> Sys.chdir path
+  | None -> raise (Fatal "Not a Cml repository (or any of the parent directories)")
+
 
 (* ($) is an infix operator for appending a char to a string *)
 let ($) (str : string) (c : char) : string =  str ^ Char.escaped c
+
 
 (************************* File Compression & Hashing *************************)
 (******************************************************************************)

--- a/utils.mli
+++ b/utils.mli
@@ -29,12 +29,25 @@ exception Fatal of string
 (***************************** Generic Helpers ********************************)
 (******************************************************************************)
 
-(* returns true if the current directory (or parent) is an initialized Cml repo,
- * otherwise raises an exception *)
+(* returns the option path to the nearest .cml directory from the cwd
+ * (current working directory). *)
+ val cml_path : string -> string option
+
+(* returns true if the path contains an initialized Cml repo,
+ * otherwise returns false *)
 val cml_initialized: string -> bool
+
+(* returns true if the current directory (or parent) is an initialized Cml repo,
+ * otherwise returns false *)
+val cml_initialized_r : string -> bool
 
 (* ($) is an infix operator for appending a char to a string *)
 val ($): string -> char -> string
+
+(* sets the cwd (current working directory) to the nearest .cml directory.
+ * Raises Fatal exception if directory is not a Cml repository
+ * (or any of the parent directories) *)
+val chdir_to_cml : unit -> unit
 
 (************************* File Compression & Hashing *************************)
 (******************************************************************************)


### PR DESCRIPTION
Created a few helper functions for accessing the .cml repository, when the user calls CamlControl from a subdirectory. I don't think any of the code you guys have written will be affected (except now it will correctly find if a super directory contains .cml). I didn't want to change your command.ml (add, branch, etc.) yet, but if you think this looks good, I can.