### PR TITLE
Brandon/subdir support

### DIFF
--- a/command.ml
+++ b/command.ml
@@ -223,16 +223,21 @@ let rm (args: string list) : unit =
   if args = [] then
     raise (Fatal "no files specified")
   else begin
+    let cwd = Sys.getcwd () in
+    chdir_to_cml ();
+    let idx = get_index () in
+    let removable_files = get_staged_help idx in
+    Sys.chdir cwd;
     let remove_from_idx rel_path =
       if Sys.file_exists rel_path then begin
         let rm_files = get_files_from_rel_path rel_path in
-        rm_files_from_idx rm_files
+        rm_files_from_idx rm_files removable_files
       end else if rel_path = "-A" then begin
         let cwd = Sys.getcwd () in
         chdir_to_cml ();
         let rm_files = get_all_files ["./"] [] in
         Sys.chdir cwd;
-        rm_files_from_idx rm_files
+        rm_files_from_idx rm_files removable_files
       end else
         raise (Fatal ("pathspec '"^rel_path^"' does not match an file(s)"))
     in

--- a/utils.ml
+++ b/utils.ml
@@ -294,11 +294,11 @@ let set_index (idx : index) : unit =
   write_index (open_out ".cml/index") idx
 
 (* removes [rm_files] list from the index *)
-let rm_files_from_idx rm_files =
+let rm_files_from_idx rm_files removable_files =
   let cwd = Sys.getcwd () in
   chdir_to_cml ();
   let idx = get_index () in
-  let idx' = List.filter (fun (s,_) -> not (List.mem s rm_files)) idx in
+  let idx' = List.filter (fun (s,_) -> not ((List.mem s rm_files) && (List.mem s removable_files))) idx in
   set_index idx';
   Sys.chdir cwd
 

--- a/utils.mli
+++ b/utils.mli
@@ -124,7 +124,7 @@ val update_index: string * string -> index -> index
 val set_index: index -> unit
 
 (* removes [rm_files] list from the index *)
-val rm_files_from_idx : string list -> unit
+val rm_files_from_idx : string list -> string list -> unit
 
 (* adds [add_files] list from the index *)
 val add_files_to_idx : string list -> unit


### PR DESCRIPTION
Added `chdir_to_cml` to `branch`, `checkout`, `commit`, `log`, `status`, `user` so now you should be able to access those functions from subdirectories of the repo. Let me know if one of them should not have `chdir_to_cml`