### PR TITLE
cml log now prints bottom-up but is no longer tail-recursive

### DIFF
--- a/command.ml
+++ b/command.ml
@@ -310,9 +310,9 @@ let init () : unit =
 let log () : unit =
   chdir_to_cml ();
   let rec log_loop ptr cmt =
-    let _ = print_commit ptr cmt.author cmt.date cmt.message in
-    if cmt.parent = "None" then ()
-    else cmt.parent |> parse_commit |> log_loop cmt.parent
+    if cmt.parent <> "None" then
+      cmt.parent |> parse_commit |> log_loop cmt.parent;
+    print_commit ptr cmt.author cmt.date cmt.message
   in try
     let head = get_head_safe () in
     parse_commit head |> log_loop head
@@ -326,9 +326,9 @@ let log () : unit =
 
 (* perform fast-forward merge by updating the head to the branch head *)
 let merge_fast_forward (branch : string) (ptr : string) : unit =
-  print ("Updating branch '" ^ branch ^ "' with fast-forward merge...");
+  print "Performing fast-forward merge...";
   set_head ptr; switch_version ptr;
-  print "\nMerge successful."
+  print ("Branch '" ^ branch ^ "' is now up-to-date.")
 
 (* join two or more development histories together *)
 let merge (args: string list) : unit =


### PR DESCRIPTION
- Before `cml log` performed like `git log` and display most recent commits at the top of the stack (printed these out first) and the earliest commits were displayed at the bottom. However, in `git` you manually scroll down to see earlier commits, but for `cml` it's harder to do that and it was just printing ALL the commits. If a repo had 10+ commits you'd have to scroll up a bunch to get the most recent commits.

- I changed the log function to print the earliest commits first, but this made the implementation not tail-recursive so it's more computationally heavy. But I think it might make more sense visually to do this